### PR TITLE
Bugifx:Remove data parts in moving folders 

### DIFF
--- a/src/Storages/MergeTree/MergeTreePartsMover.h
+++ b/src/Storages/MergeTree/MergeTreePartsMover.h
@@ -40,6 +40,7 @@ public:
         : data(data_)
         , log(&Poco::Logger::get("MergeTreePartsMover"))
     {
+        clearMovingDataParts();
     }
 
     /// Select parts for background moves according to storage_policy configuration.
@@ -58,6 +59,9 @@ public:
     /// cloned part will be removed and log message will be reported. It may happen in case of concurrent
     /// merge or mutation.
     void swapClonedPart(const std::shared_ptr<const IMergeTreeDataPart> & cloned_parts) const;
+
+    /// Clear moving data parts in moving folders.
+    void clearMovingDataParts();
 
     /// Can stop background moves and moves from queries
     ActionBlocker moves_blocker;


### PR DESCRIPTION
Remove data parts in moving folders  when data parts are merged or anything else hanpped.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature
- Improvement
- Bug Fix (user-visible misbehavior in official stable or prestable release)
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
