### PR TITLE
fix create table on cluster

### DIFF
--- a/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
@@ -47,9 +47,9 @@ std::pair<bool, ReplicatedMergeMutateTaskBase::PartLogWriter> MergeFromLogEntryT
     /// and it may be better to spread merges tasks across the replicas
     /// instead of doing exactly the same merge cluster-wise
 
-    if (storage.merge_strategy_picker.shouldMergeOnSingleReplica(entry))
+    if (storage.merge_strategy_picker->shouldMergeOnSingleReplica(entry))
     {
-        std::optional<String> replica_to_execute_merge = storage.merge_strategy_picker.pickReplicaToExecuteMerge(entry);
+        std::optional<String> replica_to_execute_merge = storage.merge_strategy_picker->pickReplicaToExecuteMerge(entry);
         if (replica_to_execute_merge)
         {
             LOG_DEBUG(log,
@@ -209,7 +209,7 @@ std::pair<bool, ReplicatedMergeMutateTaskBase::PartLogWriter> MergeFromLogEntryT
     transaction_ptr = std::make_unique<MergeTreeData::Transaction>(storage);
     stopwatch_ptr = std::make_unique<Stopwatch>();
 
-    merge_task = storage.merger_mutator.mergePartsToTemporaryPart(
+    merge_task = storage.merger_mutator->mergePartsToTemporaryPart(
             future_merged_part,
             metadata_snapshot,
             merge_mutate_entry.get(),
@@ -243,7 +243,7 @@ bool MergeFromLogEntryTask::finalize(ReplicatedMergeMutateTaskBase::PartLogWrite
     /// Task is not needed
     merge_task.reset();
 
-    storage.merger_mutator.renameMergedTemporaryPart(part, parts, transaction_ptr.get());
+    storage.merger_mutator->renameMergedTemporaryPart(part, parts, transaction_ptr.get());
 
     try
     {

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -228,6 +228,13 @@ public:
         [[maybe_unused]] const String & part_name,
         [[maybe_unused]] const String & value) const { return nullptr; }
 
+    virtual DistributeLockGuardPtr getDistributeLockGuardInInit(
+        [[maybe_unused]] const String& disk_name,
+        [[maybe_unused]] const String& part_name,
+        [[maybe_unused]] const String& value) const {
+        return nullptr;
+    }
+
     MergeTreeDataPartType choosePartType(size_t bytes_uncompressed, size_t rows_count) const;
     MergeTreeDataPartType choosePartTypeOnDisk(size_t bytes_uncompressed, size_t rows_count) const;
 
@@ -960,6 +967,8 @@ public:
     /// Mutex for currently_submerging_parts and currently_emerging_parts
     mutable std::mutex currently_submerging_emerging_mutex;
 
+    void init();
+
 protected:
     friend class IMergeTreeDataPart;
     friend class MergeTreeDataMergerMutator;
@@ -1268,6 +1277,12 @@ private:
     virtual std::optional<ZeroCopyLock> tryCreateZeroCopyExclusiveLock(const String &, const DiskPtr &) { return std::nullopt; }
 
     TemporaryParts temporary_parts;
+
+    MergeTreeDataFormatVersion min_format_version;
+    const StorageInMemoryMetadata storage_metadata;
+    bool attach_table;
+    const String date_column;
+    ContextMutablePtr context_ptr;
 };
 
 /// RAII struct to record big parts that are submerging or emerging.

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -51,7 +51,7 @@ struct Settings;
     M(UInt64, min_rows_to_fsync_after_merge, 0, "Minimal number of rows to do fsync for part after merge (0 - disabled)", 0) \
     M(UInt64, min_compressed_bytes_to_fsync_after_merge, 0, "Minimal number of compressed bytes to do fsync for part after merge (0 - disabled)", 0) \
     M(UInt64, min_compressed_bytes_to_fsync_after_fetch, 0, "Minimal number of compressed bytes to do fsync for part after fetch (0 - disabled)", 0) \
-    M(Bool, fsync_after_insert, false, "Do fsync for every inserted part. Significantly decreases performance of inserts, not recommended to use with wide parts.", 0) \
+    M(Bool, fsync_after_insert, true, "Do fsync for every inserted part. Significantly decreases performance of inserts, not recommended to use with wide parts.", 0) \
     M(Bool, fsync_part_directory, false, "Do fsync for part directory after all part operations (writes, renames, etc.).", 0) \
     M(UInt64, write_ahead_log_bytes_to_fsync, 100ULL * 1024 * 1024, "Amount of bytes, accumulated in WAL to do fsync.", 0) \
     M(UInt64, write_ahead_log_interval_ms_to_fsync, 100, "Interval in milliseconds after which fsync for WAL is being done.", 0) \

--- a/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
@@ -56,9 +56,9 @@ std::pair<bool, ReplicatedMergeMutateTaskBase::PartLogWriter> MutateFromLogEntry
     /// and it may be better to spread merges tasks across the replicas
     /// instead of doing exactly the same merge cluster-wise
 
-    if (storage.merge_strategy_picker.shouldMergeOnSingleReplica(entry))
+    if (storage.merge_strategy_picker->shouldMergeOnSingleReplica(entry))
     {
-        std::optional<String> replica_to_execute_merge = storage.merge_strategy_picker.pickReplicaToExecuteMerge(entry);
+        std::optional<String> replica_to_execute_merge = storage.merge_strategy_picker->pickReplicaToExecuteMerge(entry);
         if (replica_to_execute_merge)
         {
             LOG_DEBUG(log,
@@ -70,7 +70,7 @@ std::pair<bool, ReplicatedMergeMutateTaskBase::PartLogWriter> MutateFromLogEntry
     }
 
     new_part_info = MergeTreePartInfo::fromPartName(entry.new_part_name, storage.format_version);
-    commands = MutationCommands::create(storage.queue.getMutationCommands(source_part, new_part_info.mutation));
+    commands = MutationCommands::create(storage.queue->getMutationCommands(source_part, new_part_info.mutation));
 
     /// Once we mutate part, we must reserve space on the same disk, because mutations can possibly create hardlinks.
     /// Can throw an exception.
@@ -141,7 +141,7 @@ std::pair<bool, ReplicatedMergeMutateTaskBase::PartLogWriter> MutateFromLogEntry
     fake_query_context->makeQueryContext();
     fake_query_context->setCurrentQueryId("");
 
-    mutate_task = storage.merger_mutator.mutatePartToTemporaryPart(
+    mutate_task = storage.merger_mutator->mutatePartToTemporaryPart(
             future_mutated_part, metadata_snapshot, commands, merge_mutate_entry.get(),
             entry.create_time, fake_query_context, reserved_space, table_lock_holder);
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp
@@ -457,7 +457,7 @@ void ReplicatedMergeTreeCleanupThread::clearOldMutations()
     if (!storage_settings->finished_mutations_to_keep)
         return;
 
-    if (storage.queue.countFinishedMutations() <= storage_settings->finished_mutations_to_keep)
+    if (storage.queue->countFinishedMutations() <= storage_settings->finished_mutations_to_keep)
     {
         /// Not strictly necessary, but helps to avoid unnecessary ZooKeeper requests.
         /// If even this replica hasn't finished enough mutations yet, then we don't need to clean anything.

--- a/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.cpp
@@ -234,7 +234,7 @@ void ReplicatedMergeTreePartCheckThread::searchForMissingPartAndFetchIfPossible(
         if (lost_part_info.level != 0 || lost_part_info.mutation != 0)
         {
             Strings source_parts;
-            bool part_in_queue = storage.queue.checkPartInQueueAndGetSourceParts(part_name, source_parts);
+            bool part_in_queue = storage.queue->checkPartInQueueAndGetSourceParts(part_name, source_parts);
 
             /// If it's MERGE/MUTATION etc. we shouldn't replace result part with empty part
             /// because some source parts can be lost, but some of them can exist.

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -61,7 +61,7 @@ private:
     using InsertsByTime = std::set<LogEntryPtr, ByTime>;
 
     StorageReplicatedMergeTree & storage;
-    ReplicatedMergeTreeMergeStrategyPicker & merge_strategy_picker;
+    std::shared_ptr<ReplicatedMergeTreeMergeStrategyPicker>  merge_strategy_picker;
     MergeTreeDataFormatVersion format_version;
 
     String zookeeper_path;
@@ -201,7 +201,7 @@ private:
       */
     bool shouldExecuteLogEntry(
         const LogEntry & entry, String & out_postpone_reason,
-        MergeTreeDataMergerMutator & merger_mutator, MergeTreeData & data,
+        std::shared_ptr<MergeTreeDataMergerMutator>& merger_mutator, MergeTreeData& data,
         std::lock_guard<std::mutex> & state_lock) const;
 
     Int64 getCurrentMutationVersionImpl(const String & partition_id, Int64 data_version, std::lock_guard<std::mutex> & /* state_lock */) const;
@@ -282,7 +282,7 @@ private:
     size_t current_multi_batch_size = 1;
 
 public:
-    ReplicatedMergeTreeQueue(StorageReplicatedMergeTree & storage_, ReplicatedMergeTreeMergeStrategyPicker & merge_strategy_picker_);
+    ReplicatedMergeTreeQueue(StorageReplicatedMergeTree& storage_, std::shared_ptr<ReplicatedMergeTreeMergeStrategyPicker> merge_strategy_picker_);
     ~ReplicatedMergeTreeQueue();
 
     /// Clears queue state
@@ -358,7 +358,7 @@ public:
     };
 
     using SelectedEntryPtr = std::shared_ptr<SelectedEntry>;
-    SelectedEntryPtr selectEntryToProcess(MergeTreeDataMergerMutator & merger_mutator, MergeTreeData & data);
+    SelectedEntryPtr selectEntryToProcess(std::shared_ptr<MergeTreeDataMergerMutator>& merger_mutator, MergeTreeData& data);
 
     /** Execute `func` function to handle the action.
       * In this case, at runtime, mark the queue element as running

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -150,7 +150,7 @@ void ReplicatedMergeTreeSink::consume(Chunk chunk)
     if (quorum)
         checkQuorumPrecondition(zookeeper);
 
-    auto part_blocks = storage.writer.splitBlockIntoParts(block, max_parts_per_block, metadata_snapshot, context);
+    auto part_blocks = storage.writer->splitBlockIntoParts(block, max_parts_per_block, metadata_snapshot, context);
     std::vector<ReplicatedMergeTreeSink::DelayedChunk::Partition> partitions;
     String block_dedup_token;
 
@@ -160,7 +160,7 @@ void ReplicatedMergeTreeSink::consume(Chunk chunk)
 
         /// Write part to the filesystem under temporary name. Calculate a checksum.
 
-        auto temp_part = storage.writer.writeTempPart(current_block, metadata_snapshot, context);
+        auto temp_part = storage.writer->writeTempPart(current_block, metadata_snapshot, context);
 
         /// If optimize_on_insert setting is true, current_block could become empty after merge
         /// and we didn't create part.

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -683,8 +683,8 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             std::move(storage_settings),
             args.has_force_restore_data_flag,
             allow_renaming);
-    else
-        return StorageMergeTree::create(
+    else {
+        auto storage = StorageMergeTree::create(
             args.table_id,
             args.relative_data_path,
             metadata,
@@ -694,6 +694,9 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             merging_params,
             std::move(storage_settings),
             args.has_force_restore_data_flag);
+        storage->init();
+        return storage;
+    }
 }
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
修复create table on cluster创建失败问题
重构StorageReplicatedMergeTree, MergeTreeData两个类的初始化流程，防止出现部分虚函数失效问题
修改fsync_after_insert默认值为true

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
